### PR TITLE
Fix xupnpd.patch

### DIFF
--- a/patches/xupnpd.patch
+++ b/patches/xupnpd.patch
@@ -320,7 +320,7 @@
  
  -- max url cache size
  cfg.cache_size=8
-@@ -76,12 +77,14 @@
+@@ -77,7 +77,7 @@
  cfg.default_mime_type='mpeg'
  
  -- feeds update interval (seconds, 0 - disabled)
@@ -328,11 +328,13 @@
 +cfg.feeds_update_interval=3600
  cfg.playlists_update_interval=0
  
+ -- host for UI playlist download
+@@ -86,6 +86,8 @@
  -- playlist (m3u file path or path with alias
  playlist=
  {
-+   { '/hdd/movie', 'Local Record Files' },
-+   { '/hdd/pictures', 'Local Picture Files' },
++      { '/hdd/movie', 'Local Record Files' },
++      { '/hdd/pictures', 'Local Picture Files' },
  --    { './playlists/mozhay.m3u', 'Mozhay.tv' },
  --    { './localmedia', 'Local Media Files' }
  --    { './private', 'Private Media Files', '127.0.0.1;192.168.1.1' }  -- only for 127.0.0.1 and 192.168.1.1


### PR DESCRIPTION
Start build of neutrino-plugin-xupnpd.
Applying Patch: xupnpd.patch
patching file src/Makefile
patching file src/rules.mk
patching file src/plugins/xupnpd_coolstream.lua
patching file src/xupnpd.lua
Hunk #5 FAILED at 77.
Hunk #6 succeeded at 105 (offset 3 lines).
Hunk #7 succeeded at 118 (offset 3 lines).
1 out of 7 hunks FAILED -- saving rejects to file src/xupnpd.lua.rej
patching file src/ui/xupnpd_ui.lua
Hunk #1 succeeded at 24 with fuzz 1.
patching file src/xupnpd_m3u.lua
patching file src/xupnpd_main.lua